### PR TITLE
Fix: plugin to handle keystore errors before biometrics validation…

### DIFF
--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -24,6 +24,7 @@ import java.security.InvalidKeyException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import javax.crypto.Cipher
+import javax.crypto.IllegalBlockSizeException
 
 private val logger = KotlinLogging.logger {}
 
@@ -198,6 +199,14 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                         return cb(null)
                     } catch (e: UserNotAuthenticatedException) {
                         logger.debug(e) { "User requires (re)authentication. showing prompt ..." }
+                    } catch (e: IllegalBlockSizeException) {
+                        resetStorage()
+                        result.error(
+                            "AuthError:${AuthenticationError.ResetBiometrics}",
+                            "auth:trying to ask for a prompt with an invalid key",
+                            "auth:trying to ask for a prompt with an invalid key"
+                        )
+                        return
                     }
                 }
 


### PR DESCRIPTION
We were only validating for the Invalid key after the prompt is shown, there is a possibility in certain scenarios it can happen before the prompt is shown. 
This check would catch, delete storage and report it to the caller