### PR TITLE
Bump win32 version range specifier

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   plugin_platform_interface: ^2.0.0
 
   ffi: '>=1.0.0 <3.0.0'
-  win32: '>=2.0.0 <4.0.0'
+  win32: '>=2.0.0 <5.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
We are seeing the following error, by bumping the allowed version here we can allow `share_plus` and `biometric_storage` to resolve to a common version of `win32`. The example project of `biometric_storage` still builds fine on ios and android with this change. There is an open [PR](https://github.com/authpass/biometric_storage/pull/98) on the upstream repo however as we use this fork we can update the fork here and once merged update the `ref:` commit in the main project.

```
Resolving dependencies... (10.8s)
Because every version of pdf_viewer from path depends on share from path which depends on share_plus ^7.0.0, every version of pdf_viewer from path requires share_plus
  ^7.0.0.
And because share_plus >=7.0.0 depends on win32 ^4.0.0, every version of pdf_viewer from path requires win32 ^4.0.0.
And because every version of secure_storage from path depends on biometric_storage from git which depends on win32 >=2.0.0 <4.0.0, pdf_viewer from path is incompatible
  with secure_storage from path.
```