### PR TITLE
KI-15396: Device Pin Fallback

### DIFF
--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -244,9 +244,9 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
 
                     val options = call.argument<Map<String, Any>>("options")?.let { it ->
                         InitOptions(
-                            authenticationValidityDurationSeconds = it["authenticationValidityDurationSeconds"] as Int,
+                            authenticationValidityDurationSeconds = if (it["authenticationDevicePinFallback"] as? Boolean ?: false) 1 else it["authenticationValidityDurationSeconds"] as Int,
                             authenticationRequired = it["authenticationRequired"] as Boolean,
-                            androidBiometricOnly = it["androidBiometricOnly"] as Boolean,
+                            androidBiometricOnly = if (it["authenticationDevicePinFallback"] as? Boolean ?: false) false else it["androidBiometricOnly"] as Boolean,
                         )
                     } ?: InitOptions()
 //                    val options = moshi.adapter(InitOptions::class.java)

--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -244,6 +244,9 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
 
                     val options = call.argument<Map<String, Any>>("options")?.let { it ->
                         InitOptions(
+                            // Change in authenticationValidityDurationSeconds to > 0 is needed when setting androidBiometricOnly to false 
+                            //  https://github.com/authpass/biometric_storage/issues/12#issuecomment-902508609
+                            //  https://pub.dev/documentation/biometric_storage/latest/biometric_storage/StorageFileInitOptions/androidBiometricOnly.html
                             authenticationValidityDurationSeconds = if (it["authenticationDevicePinFallback"] as? Boolean ?: false) 1 else it["authenticationValidityDurationSeconds"] as Int,
                             authenticationRequired = it["authenticationRequired"] as Boolean,
                             androidBiometricOnly = if (it["authenticationDevicePinFallback"] as? Boolean ?: false) false else it["androidBiometricOnly"] as Boolean,

--- a/lib/src/biometric_storage.dart
+++ b/lib/src/biometric_storage.dart
@@ -86,6 +86,7 @@ class StorageFileInitOptions {
     this.authenticationValidityDurationSeconds = -1,
     this.authenticationRequired = true,
     this.androidBiometricOnly = true,
+    this.authenticationDevicePinFallback = false,
   });
 
   final int authenticationValidityDurationSeconds;
@@ -105,11 +106,16 @@ class StorageFileInitOptions {
   /// https://github.com/authpass/biometric_storage/issues/12#issuecomment-902508609
   final bool androidBiometricOnly;
 
+  /// Whether to fallback to device PIN when Touch/Face ID is not recognized
+  /// or use device PIN directly if Touch/Face ID is disabled
+  final bool authenticationDevicePinFallback;
+
   Map<String, dynamic> toJson() => <String, dynamic>{
         'authenticationValidityDurationSeconds':
             authenticationValidityDurationSeconds,
         'authenticationRequired': authenticationRequired,
         'androidBiometricOnly': androidBiometricOnly,
+        'authenticationDevicePinFallback': authenticationDevicePinFallback,
       };
 }
 


### PR DESCRIPTION
This PR introduces an additional param to the native plugin code `authenticationDevicePinFallback` which is used for Device PIN fallback upon biometric challenge.

Example usage can be found [here](https://github.com/tideplatform/universal-client/pull/9765)

